### PR TITLE
Allow Knox usage server side

### DIFF
--- a/s3server.js
+++ b/s3server.js
@@ -1,4 +1,4 @@
-var Knox = Npm.require("knox");
+Knox = Npm.require("knox");
 var Future = Npm.require('fibers/future');
 
 var knox;


### PR DESCRIPTION
The `var` keyword restricts the use of it to this file only. Removing it lets `package.js` see it and export it
