### PR TITLE
Return url from method so that it could be used on the client

### DIFF
--- a/s3server.js
+++ b/s3server.js
@@ -29,6 +29,7 @@ Meteor.methods({
 		if(future.wait() && callback){
 			var url = knox.http(future.wait());
 			Meteor.call(callback,url,context);
+			return url;
 		}
 	},
 	S3delete:function(path, callback){


### PR DESCRIPTION
This way you can supply an additional callback method to be executed in the front-end which would receive the url.

i.e

```
// Client-side
Meteor.call("S3upload",fileData,context,callbackFunction, function(err, url){
  // do something with the url server side
});
```

Note the callbackFunction is still the name of the method that will be executed server-side, not the asyncCallback that's called automatically by default. (I think that moving forward the callbackFunction should be made optional as well)
