### PR TITLE
fixes for if user does not specifies the optional 'directory' attribute ...

### DIFF
--- a/s3server.js
+++ b/s3server.js
@@ -15,7 +15,7 @@ Meteor.methods({
 
 		var extension = (file.name).match(/\.[0-9a-z]{1,5}$/i);
 		file.name = Meteor.uuid()+extension;
-		var path = S3.config.directory+file.name;
+    var path = ( S3.config.directory === undefined || S3.config.directory === null) ? file.name : S3.config.directory+file.name;
 
 		var buffer = new Buffer(file.data);
 


### PR DESCRIPTION
...in 'S3.config' object

if user does not specify the optional 'directory' attibute, in final name of uploaded file-name, gets undefined in it. due to directory attribute being 'undefined'  
`
 http://s3.amazonaws.com/<bucket-name>/**undefined**69f049b8-ea15-46fd-ad9a-3b715f59606d.png
`
