### PR TITLE
initialize aws-sdk with region

### DIFF
--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -25,4 +25,5 @@ Meteor.startup ->
 	S3.aws = new AWS.S3
 		accessKeyId:S3.config.key
 		secretAccessKey:S3.config.secret
+		region:S3.config.region
 


### PR DESCRIPTION
I was having trouble uploading to `eu-west-1` region with a 12 MB file (but not with a 3 MB file). I saw the following error on the server:

    I20141106-20:25:47.891(1)? Exception in callback of async function: Error: PermanentRedirect: The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint. [aws.createMpu]
    I20141106-20:25:47.892(1)?     at packages/lepozepo:s3/server/methods.coffee:163:16
    I20141106-20:25:47.892(1)?     at runWithEnvironment (packages/meteor/dynamics_nodejs.js:108)

This led me to include the region when instantiating the AWS object from the aws-sdk package, which fixes the problem.