### PR TITLE
Add bucket's region requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Template.s3_tester.helpers({
 ```
 
 ## Create your Amazon S3
-For all of this to work you need to create an aws account. On their website create navigate to S3 and create a bucket. Navigate to your bucket and on the top right side you'll see your account name. Click it and go to Security Credentials. Once you're in Security Credentials create a new access key under the Access Keys (Access Key ID and Secret Access Key) tab. This is the info you will use for the first step of this plug. Go back to your bucket and select the properties OF THE BUCKET, not a file. Under Static Website Hosting you can Enable website hosting, to do that first upload a blank index.html file and then enable it. YOU'RE NOT DONE.
+For all of this to work you need to create an aws account. On their website create navigate to S3 and create a bucket in region US Standard. Navigate to your bucket and on the top right side you'll see your account name. Click it and go to Security Credentials. Once you're in Security Credentials create a new access key under the Access Keys (Access Key ID and Secret Access Key) tab. This is the info you will use for the first step of this plug. Go back to your bucket and select the properties OF THE BUCKET, not a file. Under Static Website Hosting you can Enable website hosting, to do that first upload a blank index.html file and then enable it. YOU'RE NOT DONE.
 
 You need to set permissions so that everyone can see what's in there. Under the Permissions tab click Edit CORS Configuration and paste this:
 


### PR DESCRIPTION
First, thank you very much for this package.

I've been playing with it today and struggled a lot to make it work but the problem was very simple.
I had created the bucket in region Frankfurt and it doesn't work if the region is not US Standard so I thought it would be useful to add it to the readme.