### PR TITLE
Add ability to deny all delete calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ __Parameters:__
 *	__ops.key [REQUIRED]:__ Your Amazon AWS Key.
 *	__ops.secret [REQUIRED]:__ Your Amazon AWS Secret.
 *	__ops.bucket [REQUIRED]:__ Your Amazon AWS S3 bucket.
+*	__ops.denyDelete [DEFAULT: undefined]:__ If set to true, will block delete calls. This is to enable secure deployment of this package before a more granular permissions system is developed.
 *	__ops.region [DEFAULT: "us-east-1"]:__ Your Amazon AWS S3 Region. Defaults to US Standard. Can be any of the following:
 	* "us-west-2"
 	* "us-west-1"

--- a/server/delete_object.coffee
+++ b/server/delete_object.coffee
@@ -8,11 +8,19 @@ Meteor.methods
 
 		future = new Future()
 
-		S3.knox.deleteFile path, (e,r) ->
-			if e
-				console.log e
-				future.return e
-			else
-				future.return true
+		if S3.config.denyDelete
+			errorMessage = 'S3.denyDelete is true, so delete was blocked.'
+			console.log errorMessage
+			e = new Error(errorMessage)
+			future.return e
+
+		else
+			console.log 'deleting'
+			S3.knox.deleteFile path, (e,r) ->
+				if e
+					console.log e
+					future.return e
+				else
+					future.return true
 
 		future.wait()


### PR DESCRIPTION
Adds a new option, `S3.config.denyDelete`. When set to true, no
delete calls are allowed. This lets the package be used to securely
allow any uploads without opening up unsecured deletes.