### PR TITLE
Fix building problems caused by npm require of aws-sdk

### DIFF
--- a/server/startup.coffee
+++ b/server/startup.coffee
@@ -1,6 +1,10 @@
 #Get Knox and AWS libraries
 Knox = Npm.require "knox"
+
+processBrowser = process.browser
+process.browser = false
 AWS = Npm.require "aws-sdk"
+process.browser = processBrowser
 
 #Server side configuration variables
 @S3 =


### PR DESCRIPTION
Fixes issues raised on this thread: https://forums.meteor.com/t/error-in-test-mode-on-1-3-typeerror-cannot-read-property-stream-of-undefined/21696/7
Fix comes from https://github.com/tjconsult 's comment.

In short the problem is:
Due to the aws-sdk having it's own implementation of require, importing aws-sdk regularly can cause some build systems to break. For me, the breakage occurs when trying to run tests, specifically using dispatch:mocha-phantomjs or practicalmeteor:mocha
This is the responsible code: https://github.com/aws/aws-sdk-js/blob/master/dist/aws-sdk.js
See the thread mentioned above for more info