### PR TITLE
add ability to set Content Disposition header

### DIFF
--- a/client/functions.coffee
+++ b/client/functions.coffee
@@ -23,6 +23,8 @@
 			# modifies the file name to a unique string, if false takes the name of the file. Uploads will overwrite existing files instead.
 		# ops.encoding [OPTIONAL: only supports "base64"]
 			# overrides file encoding, only supports base64 right now
+		# ops.content_disposition
+			# overrides file disposition (inline or attachment)
 		# ops.server_side_encryption
 			# if true, use server side encryption
 		# ops.expiration [DEFAULT: 1800000 (30 mins)]
@@ -136,6 +138,7 @@ uploadFile = (file, ops, callback) ->
 		region:ops.region
 		expiration:ops.expiration
 		server_side_encryption:ops.server_side_encryption
+		content_dispostion:ops.content_dispostion
 		(error,result) ->
 			if result
 				# Mark as signed
@@ -147,8 +150,9 @@ uploadFile = (file, ops, callback) ->
 				form_data = new FormData()
 				form_data.append "key", result.key
 				form_data.append "acl", result.acl
-				form_data.append "Content-Type",result.file_type
-
+				form_data.append "Content-Type", result.file_type
+				if ops.content_dispostion
+					form_data.append "Content-Disposition", ops.content_dispostion
 				form_data.append "X-Amz-Date", result.meta_date
 				if ops.server_side_encryption
 					form_data.append "x-amz-server-side-encryption", "AES256"

--- a/server/sign_request.coffee
+++ b/server/sign_request.coffee
@@ -9,6 +9,7 @@ Meteor.methods
 		# ops.acl
 		# ops.bucket
 		# ops.server_side_encryption
+		# ops.content_dispostion
 
 		_.defaults ops,
 			expiration:1800000
@@ -28,6 +29,7 @@ Meteor.methods
 			file_type:String
 			file_name:String
 			file_size:Number
+			content_dispostion:String
 
 		expiration = new Date Date.now() + ops.expiration
 		expiration = expiration.toISOString()
@@ -53,6 +55,8 @@ Meteor.methods
 				{"x-amz-date": meta_date }
 				{"x-amz-meta-uuid": meta_uuid}
 			]
+		if ops.content_disposition
+			policy["conditions"].push({"Content-Disposition": ops.content_disposition})
 		if ops.server_side_encryption
 			policy["conditions"].push({"x-amz-server-side-encryption": "AES256"})
 


### PR DESCRIPTION
I didn't see a way to set the Content Disposition header for files (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition) which is how you can control if something should be downloaded or viewed inline.

I added the ability to pass that flag, modeled off of @tscizzle PR: https://github.com/Lepozepo/S3/pull/140 which works well