### PR TITLE
Meteor 1.6.1 compatibility

### DIFF
--- a/client/functions.coffee
+++ b/client/functions.coffee
@@ -107,7 +107,7 @@ uploadFile = (file, ops, callback) ->
 		if not extension
 			extension = file.type.split("/")[1] # a library of extensions based on MIME types would be better
 
-		file_name = "#{Meteor.uuid()}.#{extension}"
+		file_name = "#{Random.id()}.#{extension}"
 	else
 		if _.isFunction(file.upload_name)
 			file_name = file.upload_name(file)

--- a/server/sign_request.coffee
+++ b/server/sign_request.coffee
@@ -40,7 +40,7 @@ Meteor.methods
 		else
 			key = "#{ops.path}/#{ops.file_name}"
 
-		meta_uuid = Meteor.uuid()
+		meta_uuid = Random.id()
 		meta_date = "#{moment().format('YYYYMMDD')}T000000Z"
 		meta_credential = "#{S3.config.key}/#{moment().format('YYYYMMDD')}/#{ops.region}/s3/aws4_request"
 		policy =


### PR DESCRIPTION
resolves #160

Meteor.uuid() is depreciated and not supported in 1.6.1. Replacing with Random.id()